### PR TITLE
Complete receipt points calculation service and test suite

### DIFF
--- a/src/main/java/io/yuchengzang/receiptprocessor/service/ReceiptPointsService.java
+++ b/src/main/java/io/yuchengzang/receiptprocessor/service/ReceiptPointsService.java
@@ -1,0 +1,70 @@
+package io.yuchengzang.receiptprocessor.service;
+
+import java.math.BigDecimal;
+import java.time.LocalTime;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.yuchengzang.receiptprocessor.model.Receipt;
+
+/**
+ * The ReceiptPointsService class provides services for calculating points from receipts.
+ */
+public class ReceiptPointsService {
+
+  // Create a logger for the ReceiptPointsService class
+  private static final Logger logger = LoggerFactory.getLogger(ReceiptPointsService.class);
+
+  /**
+   * Calculate the points from a receipt
+   *
+   * @param receipt the Receipt object to calculate points from. It must not be null.
+   * @return the number of points calculated from the receipt
+   * @throws IllegalArgumentException if the receipt is null
+   */
+  public int calculatePoints(Receipt receipt) throws IllegalArgumentException {
+    // Validate the input
+    if (receipt == null) {
+      logger.error("Receipt cannot be null.");
+      throw new IllegalArgumentException("Receipt cannot be null.");
+    }
+
+    // Calculate the points based on the total amount of the receipt
+    int totalPoints = 0;
+    totalPoints += calculatePointsFromRetailerName(receipt);
+
+    logger.info("Total points calculated for receipt ID '{}': '{}'", receipt.getId(), totalPoints);
+    return totalPoints;
+  }
+
+  /**
+   * Calculate the points based on the total amount of the receipt
+   *
+   * Rule: one point for every alphanumeric character in the retailer name.
+   *
+   * Example:
+   * 1) "Target" has 6 characters. So, the points for a receipt from Target is 6.
+   * 2) "M&M Corner Market", it has only 14 alphanumeric characters (' ' and '&' are not counted).
+   *
+   * @param receipt the Receipt object to calculate points from. It must not be null.
+   * @return the number of points calculated based on the total amount
+   * @throws IllegalArgumentException if the receipt is null
+   */
+  protected int calculatePointsFromRetailerName(Receipt receipt) throws IllegalArgumentException {
+    // Validate the input
+    if (receipt == null || receipt.getRetailer() == null) {
+      logger.error("Receipt cannot be null.");
+      throw new IllegalArgumentException("Receipt or retailer cannot be null.");
+    }
+
+    // Calculate the points based on the retailer name
+    String retailer = receipt.getRetailer();
+    int points = retailer.replaceAll("[^a-zA-Z0-9]", "").length();
+
+    logger.info("Receipt ID: '{}',Rule: Retailer Name, Retailer: '{}', Points: '{}'",
+        receipt.getId(), retailer, points);
+
+    return points;
+  }
+}

--- a/src/main/java/io/yuchengzang/receiptprocessor/service/ReceiptPointsService.java
+++ b/src/main/java/io/yuchengzang/receiptprocessor/service/ReceiptPointsService.java
@@ -32,7 +32,10 @@ public class ReceiptPointsService {
 
     // Calculate the points based on the total amount of the receipt
     int totalPoints = 0;
+
     totalPoints += calculatePointsFromRetailerName(receipt);
+    totalPoints += calculatePointsFromTotalAmountRoundDollar(receipt);
+    totalPoints += calculatePointsFromTotalAmountMultipleOfQuarter(receipt);
 
     logger.info("Total points calculated for receipt ID '{}': '{}'", receipt.getId(), totalPoints);
     return totalPoints;
@@ -69,7 +72,8 @@ public class ReceiptPointsService {
   }
 
   /**
-   * Calculate the points based on the total amount of the receipt
+   * Calculate the points based on the total amount of the receipt, where the total amount is a
+   * round dollar amount with no cents.
    *
    * Rule: 50 points if the total is a round dollar amount with no cents.
    *
@@ -99,6 +103,45 @@ public class ReceiptPointsService {
 
     int points = isRoundDollar ? 50 : 0;
     logger.info("Receipt ID: '{}', Rule: Total Amount Round Dollar, Total Amount: '{}', "
+        + "Points: '{}'", receipt.getId(), totalAmount, points);
+
+    return points;
+  }
+
+  /**
+   * Calculate the points based on the total amount of the receipt, where the total amount is a
+   * multiple of 0.25.
+   *
+   * Rule: 25 points if the total is a multiple of 0.25
+   *
+   * Example:
+   * 1) Total amount is $12.25, so the points for this receipt is 25.
+   * 2) Total amount if $15.50, so the points for this receipt is 25.
+   * 3) Total amount is $10.75, so the points for this receipt is 25.
+   * 4) Total amount is $99.00, so the points for this receipt is 25.
+   * 5) Total amount is $99.99, so the points for this receipt is 0.
+   *
+   * @param receipt the Receipt object to calculate points from. It must not be null.
+   * @return the number of points calculated based on the total amount. It will be 25 if the total
+   *         amount is a multiple of 0.25, 0 otherwise.
+   * @throws IllegalArgumentException if the receipt or its total amount is null
+   */
+  protected int calculatePointsFromTotalAmountMultipleOfQuarter(Receipt receipt)
+      throws IllegalArgumentException {
+    if (receipt == null || receipt.getTotalAmount() == null) {
+      logger.error("Receipt or total amount cannot be null.");
+      throw new IllegalArgumentException("Receipt or total amount cannot be null.");
+    }
+
+    // Compute the points based on the total amount
+    BigDecimal totalAmount = receipt.getTotalAmount();
+
+    // Check if the total amount is a multiple of 0.25
+    boolean isMultipleOfQuarter = totalAmount.remainder(new BigDecimal("0.25"))
+        .compareTo(BigDecimal.ZERO) == 0;
+
+    int points = isMultipleOfQuarter ? 25 : 0;
+    logger.info("Receipt ID: '{}', Rule: Total Amount Multiple of Quarter, Total Amount: '{}', "
         + "Points: '{}'", receipt.getId(), totalAmount, points);
 
     return points;

--- a/src/main/java/io/yuchengzang/receiptprocessor/service/ReceiptPointsService.java
+++ b/src/main/java/io/yuchengzang/receiptprocessor/service/ReceiptPointsService.java
@@ -70,7 +70,7 @@ public class ReceiptPointsService {
     String retailer = receipt.getRetailer();
     int points = retailer.replaceAll("[^a-zA-Z0-9]", "").length();
 
-    logger.info("Receipt ID: '{}',Rule: Retailer Name, Retailer: '{}', Points: '{}'",
+    logger.info("Receipt ID: '{}', Rule: Retailer Name, Retailer: '{}', Points: '{}'",
         receipt.getId(), retailer, points);
 
     return points;

--- a/src/main/java/io/yuchengzang/receiptprocessor/service/ReceiptPointsService.java
+++ b/src/main/java/io/yuchengzang/receiptprocessor/service/ReceiptPointsService.java
@@ -38,6 +38,8 @@ public class ReceiptPointsService {
     totalPoints += calculatePointsFromTotalAmountRoundDollar(receipt);
     totalPoints += calculatePointsFromTotalAmountMultipleOfQuarter(receipt);
     totalPoints += calculatePointsFromItemCount(receipt);
+    totalPoints += calculatePointsFromItemDescriptionLength(receipt);
+    totalPoints += calculatePointsFromPurchaseDate(receipt);
 
     logger.info("Total points calculated for receipt ID '{}': '{}'", receipt.getId(), totalPoints);
     return totalPoints;
@@ -229,6 +231,43 @@ public class ReceiptPointsService {
 
     logger.info("Receipt ID: '{}', Rule: Item Description Length, Points: '{}'",
         receipt.getId(), points);
+
+    return points;
+  }
+
+  /**
+   * Calculate the points based on the purchase date of the receipt
+   *
+   * Rule: 6 points if the day in the purchase date is odd.
+   *
+   * Example:
+   * 1) Purchase date: 2022-01-01, Points: 6
+   * 2) Purchase date: 2022-01-02, Points: 0
+   * 3) Purchase date: 2022-01-31, Points: 6
+   * 4) Purchase date: 2022-02-28, Points: 0
+   * 5) Purchase date: 2020-02-29, Points: 6 (leap year)
+   *
+   * @param receipt the Receipt object to calculate points from. It must not be null.
+   * @return the number of points calculated based on the purchase date
+   */
+  protected int calculatePointsFromPurchaseDate(Receipt receipt) {
+    // Validate the input
+    if (receipt == null || receipt.getPurchaseDate() == null) {
+      logger.error("Receipt or purchase date cannot be null.");
+      throw new IllegalArgumentException("Receipt or purchase date cannot be null.");
+    }
+
+    // Calculate the points based on the purchase date
+    int day = receipt.getPurchaseDate().getDayOfMonth();
+    int points = 0;
+
+    // Check if the day is odd. Odd days have 6 points
+    if (day % 2 == 1) {
+      points = 6;
+    }
+
+    logger.info("Receipt ID: '{}', Rule: Purchase Date, Purchase Date: '{}', Day: '{}',"
+            + " Points: '{}'", receipt.getId(), receipt.getPurchaseDate(), day, points);
 
     return points;
   }

--- a/src/main/java/io/yuchengzang/receiptprocessor/service/ReceiptPointsService.java
+++ b/src/main/java/io/yuchengzang/receiptprocessor/service/ReceiptPointsService.java
@@ -36,6 +36,7 @@ public class ReceiptPointsService {
     totalPoints += calculatePointsFromRetailerName(receipt);
     totalPoints += calculatePointsFromTotalAmountRoundDollar(receipt);
     totalPoints += calculatePointsFromTotalAmountMultipleOfQuarter(receipt);
+    totalPoints += calculatePointsFromItemCount(receipt);
 
     logger.info("Total points calculated for receipt ID '{}': '{}'", receipt.getId(), totalPoints);
     return totalPoints;
@@ -143,6 +144,41 @@ public class ReceiptPointsService {
     int points = isMultipleOfQuarter ? 25 : 0;
     logger.info("Receipt ID: '{}', Rule: Total Amount Multiple of Quarter, Total Amount: '{}', "
         + "Points: '{}'", receipt.getId(), totalAmount, points);
+
+    return points;
+  }
+
+  /**
+   * Calculate the points based on the number of items on the receipt
+   *
+   * Rule: 5 points for every two items on the receipt
+   *
+   * Example:
+   *  1) 1 item: 0 points
+   *  2) 2 items: 5 points
+   *  3) 3 items: 5 points
+   *  4) 4 items: 10 points
+   *  5) 12 items: 30 points
+   *  6) 99 items: 245 points
+   *
+   * @param receipt the Receipt object to calculate points from. It must not be null.
+   * @return the number of points calculated based on number of items on the receipt. It will be 5
+   *         points for every two items on the receipt.
+   * @throws IllegalArgumentException if the receipt or its items is null
+   */
+  protected int calculatePointsFromItemCount(Receipt receipt)
+      throws IllegalArgumentException {
+    if (receipt == null || receipt.getItems() == null) {
+      logger.error("Receipt or items cannot be null.");
+      throw new IllegalArgumentException("Receipt or items cannot be null.");
+    }
+
+    // Compute the points based on the number of items. 5 points for every two items
+    int itemsCount = receipt.getItems().size();
+    int points = itemsCount / 2 * 5;
+
+    logger.info("Receipt ID: '{}', Rule: Item Count, Items Count: '{}', Points: '{}'",
+        receipt.getId(), itemsCount, points);
 
     return points;
   }

--- a/src/test/java/io/yuchengzang/receiptprocessor/service/ReceiptPointsServiceTest.java
+++ b/src/test/java/io/yuchengzang/receiptprocessor/service/ReceiptPointsServiceTest.java
@@ -4,7 +4,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.math.BigDecimal;
+
 import io.yuchengzang.receiptprocessor.model.Receipt;
+
 public class ReceiptPointsServiceTest {
 
   /**
@@ -102,4 +105,88 @@ public class ReceiptPointsServiceTest {
       receiptPointsService.calculatePointsFromRetailerName(null);
     });
   }
+
+  /**
+   * Testing rule: 50 points if the total is a round dollar amount with no cents.
+   *
+   * Test case: Total amount is $100.00, a round dollar amount, so the points for this receipt is 50
+   */
+  @Test
+  void testValidCalculatePointsFromTotalAmountRoundDollarRound1() {
+    testReceipt.setTotalAmount(new BigDecimal("100.00"));
+    assertEquals(50,
+        receiptPointsService.calculatePointsFromTotalAmountRoundDollar(testReceipt));
+  }
+
+  /**
+   * Testing rule: 50 points if the total is a round dollar amount with no cents.
+   *
+   * Test case: Total amount is $0.00, a round dollar amount, so the points for this receipt is 50
+   */
+  @Test
+  void testValidCalculatePointsFromTotalAmountRoundDollarRound2() {
+    testReceipt.setTotalAmount(new BigDecimal("0.00"));
+    assertEquals(50,
+        receiptPointsService.calculatePointsFromTotalAmountRoundDollar(testReceipt));
+  }
+
+  /**
+   * Testing rule: 50 points if the total is a round dollar amount with no cents.
+   *
+   * Test case: Total amount is $12, a round dollar amount but without trailing ".00", so the points
+   * for this receipt is 50
+   */
+  @Test
+  void testValidCalculatePointsFromTotalAmountRoundDollarRound3() {
+    testReceipt.setTotalAmount(new BigDecimal("12"));
+    assertEquals(50,
+        receiptPointsService.calculatePointsFromTotalAmountRoundDollar(testReceipt));
+  }
+
+  /**
+   * Testing rule: 50 points if the total is a round dollar amount with no cents.
+   *
+   * Test case: Total amount is $0.01, not a round dollar amount, so the points for this receipt is
+   * 0
+   */
+  @Test
+  void testValidCalculatePointsFromTotalAmountRoundDollarNonRound1() {
+    testReceipt.setTotalAmount(new BigDecimal("0.01"));
+    assertEquals(0,
+        receiptPointsService.calculatePointsFromTotalAmountRoundDollar(testReceipt));
+  }
+
+  /**
+   * Testing rule: 50 points if the total is a round dollar amount with no cents.
+   *
+   * Test case: Total amount is $99.99, not a round dollar amount, so the points for this receipt is
+   * 0
+   */
+  @Test
+  void testValidCalculatePointsFromTotalAmountRoundDollarNonRound2() {
+    testReceipt.setTotalAmount(new BigDecimal("99.99"));
+    assertEquals(0,
+        receiptPointsService.calculatePointsFromTotalAmountRoundDollar(testReceipt));
+  }
+
+  /**
+   * Testing rule: 50 points if the total is a round dollar amount with no cents.
+   *
+   * Test case: Total amount is $10.50, not a round dollar amount, so the points for this receipt is
+   * 0
+   */
+  @Test
+  void testValidCalculatePointsFromTotalAmountRoundDollarNonRound3() {
+    testReceipt.setTotalAmount(new BigDecimal("10.50"));
+    assertEquals(0,
+        receiptPointsService.calculatePointsFromTotalAmountRoundDollar(testReceipt));
+  }
+
+  @Test
+  void testInvalidCalculatePointsFromTotalAmountRoundDollarNullReceipt() {
+    assertThrows(IllegalArgumentException.class, () -> {
+      receiptPointsService.calculatePointsFromTotalAmountRoundDollar(null);
+    });
+  }
+
 }

--- a/src/test/java/io/yuchengzang/receiptprocessor/service/ReceiptPointsServiceTest.java
+++ b/src/test/java/io/yuchengzang/receiptprocessor/service/ReceiptPointsServiceTest.java
@@ -189,4 +189,95 @@ public class ReceiptPointsServiceTest {
     });
   }
 
+  /**
+   * Testing rule: 25 points if the total is a multiple of 0.25.
+   *
+   * Test case: Total amount is $12.25, a multiple of 0.25, so the points for this receipt is 25
+   */
+  @Test
+  void testValidCalculatePointsFromTotalAmountMultipleOfQuarterMultiple1() {
+    testReceipt.setTotalAmount(new BigDecimal("12.25"));
+    assertEquals(25,
+        receiptPointsService.calculatePointsFromTotalAmountMultipleOfQuarter(testReceipt));
+  }
+
+  /**
+   * Testing rule: 25 points if the total is a multiple of 0.25.
+   *
+   * Test case: Total amount is $15.50, a multiple of 0.25, so the points for this receipt is 25
+   */
+  @Test
+  void testValidCalculatePointsFromTotalAmountMultipleOfQuarterMultiple2() {
+    testReceipt.setTotalAmount(new BigDecimal("15.50"));
+    assertEquals(25,
+        receiptPointsService.calculatePointsFromTotalAmountMultipleOfQuarter(testReceipt));
+  }
+
+  /**
+   * Testing rule: 25 points if the total is a multiple of 0.25.
+   *
+   * Test case: Total amount is $10.75, a multiple of 0.25, so the points for this receipt is 25
+   */
+  @Test
+  void testValidCalculatePointsFromTotalAmountMultipleOfQuarterMultiple3() {
+    testReceipt.setTotalAmount(new BigDecimal("10.75"));
+    assertEquals(25,
+        receiptPointsService.calculatePointsFromTotalAmountMultipleOfQuarter(testReceipt));
+  }
+
+  /**
+   * Testing rule: 25 points if the total is a multiple of 0.25.
+   *
+   * Test case: Total amount is $99.00, a multiple of 0.25, so the points for this receipt is 25
+   */
+  @Test
+  void testValidCalculatePointsFromTotalAmountMultipleOfQuarterMultiple4() {
+    testReceipt.setTotalAmount(new BigDecimal("99.00"));
+    assertEquals(25,
+        receiptPointsService.calculatePointsFromTotalAmountMultipleOfQuarter(testReceipt));
+  }
+
+  /**
+   * Testing rule: 25 points if the total is a multiple of 0.25.
+   *
+   * Test case: Total amount is 0.01, not a multiple of 0.25, so the points for this receipt is 0
+   */
+  @Test
+  void testValidCalculatePointsFromTotalAmountMultipleOfQuarterNonMultiple1() {
+    testReceipt.setTotalAmount(new BigDecimal("0.01"));
+    assertEquals(0,
+        receiptPointsService.calculatePointsFromTotalAmountMultipleOfQuarter(testReceipt));
+  }
+
+  /**
+   * Testing rule: 25 points if the total is a multiple of 0.25.
+   *
+   * Test case: Total amount is $12.26, not a multiple of 0.25, so the points for this receipt is 0
+   */
+  @Test
+  void testValidCalculatePointsFromTotalAmountMultipleOfQuarterNonMultiple2() {
+    testReceipt.setTotalAmount(new BigDecimal("12.26"));
+    assertEquals(0,
+        receiptPointsService.calculatePointsFromTotalAmountMultipleOfQuarter(testReceipt));
+  }
+
+  /**
+   * Testing rule: 25 points if the total is a multiple of 0.25.
+   *
+   * Test case: Total amount is $100.49, not a multiple of 0.25, so the points for this receipt is 0
+   */
+  @Test
+  void testValidCalculatePointsFromTotalAmountMultipleOfQuarterNonMultiple3() {
+    testReceipt.setTotalAmount(new BigDecimal("100.49"));
+    assertEquals(0,
+        receiptPointsService.calculatePointsFromTotalAmountMultipleOfQuarter(testReceipt));
+  }
+
+  @Test
+  void testInvalidCalculatePointsFromTotalAmountMultipleOfQuarterNullReceipt() {
+    assertThrows(IllegalArgumentException.class, () -> {
+      receiptPointsService.calculatePointsFromTotalAmountMultipleOfQuarter(null);
+    });
+  }
+
 }

--- a/src/test/java/io/yuchengzang/receiptprocessor/service/ReceiptPointsServiceTest.java
+++ b/src/test/java/io/yuchengzang/receiptprocessor/service/ReceiptPointsServiceTest.java
@@ -5,8 +5,11 @@ import org.junit.jupiter.api.BeforeEach;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.math.BigDecimal;
+import java.util.List;
+import java.util.Collections;
 
 import io.yuchengzang.receiptprocessor.model.Receipt;
+import io.yuchengzang.receiptprocessor.model.Item;
 
 public class ReceiptPointsServiceTest {
 
@@ -279,5 +282,101 @@ public class ReceiptPointsServiceTest {
       receiptPointsService.calculatePointsFromTotalAmountMultipleOfQuarter(null);
     });
   }
+
+  /**
+   * Testing rule: 5 points for every two items on the receipt
+   *
+   * Test case: 1 item, so the points for this receipt is 0
+   */
+  @Test
+  void testValidCalculatePointsFromItemCount1Item() {
+    Item item1 = new Item("Mountain Dew 12PK", new BigDecimal("5.99"));
+    testReceipt.setItems(List.of(item1));
+
+    assertEquals(0, receiptPointsService.calculatePointsFromItemCount(testReceipt));
+  }
+
+  /**
+   * Testing rule: 5 points for every two items on the receipt
+   *
+   * Test case: 2 items, so the points for this receipt is 5
+   */
+  @Test
+  void testValidCalculatePointsFromItemCount2Items() {
+    Item item1 = new Item("Mountain Dew 12PK", new BigDecimal("5.99"));
+    Item item2 = new Item("Coca-Cola 12PK", new BigDecimal("5.99"));
+    testReceipt.setItems(List.of(item1, item2));
+
+    assertEquals(5, receiptPointsService.calculatePointsFromItemCount(testReceipt));
+  }
+
+  /**
+   * Testing rule: 5 points for every two items on the receipt
+   *
+   * Test case: 3 items, so the points for this receipt is 5
+   */
+  @Test
+  void testValidCalculatePointsFromItemCount3Items() {
+    Item item1 = new Item("Mountain Dew 12PK", new BigDecimal("5.99"));
+    Item item2 = new Item("Coca-Cola 12PK", new BigDecimal("5.99"));
+    Item item3 = new Item("Pepsi 12PK", new BigDecimal("5.99"));
+    testReceipt.setItems(List.of(item1, item2, item3));
+
+    assertEquals(5, receiptPointsService.calculatePointsFromItemCount(testReceipt));
+  }
+
+  /**
+   * Testing rule: 5 points for every two items on the receipt
+   *
+   * Test case: 4 items, so the points for this receipt is 10
+   */
+  @Test
+  void testValidCalculatePointsFromItemCount4Items() {
+    Item item1 = new Item("Mountain Dew 12PK", new BigDecimal("5.99"));
+    Item item2 = new Item("Coca-Cola 12PK", new BigDecimal("5.99"));
+    Item item3 = new Item("Pepsi 12PK", new BigDecimal("5.99"));
+    Item item4 = new Item("Sprite 12PK", new BigDecimal("5.99"));
+    testReceipt.setItems(List.of(item1, item2, item3, item4));
+
+    assertEquals(10, receiptPointsService.calculatePointsFromItemCount(testReceipt));
+  }
+
+  /**
+   * Testing rule: 5 points for every two items on the receipt
+   *
+   * Test case: 12 items, so the points for this receipt is 30
+   */
+  @Test
+  void testValidCalculatePointsFromItemCount12Items() {
+    // Create a list of 12 items
+    Item item = new Item("Mountain Dew 12PK", new BigDecimal("5.99"));
+    List<Item> items = Collections.nCopies(12, item);
+    testReceipt.setItems(items);
+
+    assertEquals(30, receiptPointsService.calculatePointsFromItemCount(testReceipt));
+  }
+
+  /**
+   * Testing rule: 5 points for every two items on the receipt
+   *
+   * Test case: 99 items, so the points for this receipt is 245
+   */
+  @Test
+  void testValidCalculatePointsFromItemCount99Items() {
+    // Create a list of 99 items
+    Item item = new Item("Mountain Dew 12PK", new BigDecimal("5.99"));
+    List<Item> items = Collections.nCopies(99, item);
+    testReceipt.setItems(items);
+
+    assertEquals(245, receiptPointsService.calculatePointsFromItemCount(testReceipt));
+  }
+
+  @Test
+  void testInvalidCalculatePointsFromItemCountNullReceipt() {
+    assertThrows(IllegalArgumentException.class, () -> {
+      receiptPointsService.calculatePointsFromItemCount(null);
+    });
+  }
+
 
 }

--- a/src/test/java/io/yuchengzang/receiptprocessor/service/ReceiptPointsServiceTest.java
+++ b/src/test/java/io/yuchengzang/receiptprocessor/service/ReceiptPointsServiceTest.java
@@ -839,7 +839,7 @@ public class ReceiptPointsServiceTest {
    * Total Points: 28
    */
   @Test
-  void testCalculatePointsAfternoonReceipt() {
+  void testCalculatePointsTargetReceipt() {
     // Create the receipt and item objects
     Item item1 = new Item("Mountain Dew 12PK", new BigDecimal("6.49"));
     Item item2 = new Item("Emils Cheese Pizza", new BigDecimal("12.25"));
@@ -898,7 +898,7 @@ public class ReceiptPointsServiceTest {
    * Total Points: 109
    */
   @Test
-  void testCalculatePointsCornerMarketReceipt() {
+  void testCalculatePointsMnMCornerMarketReceipt() {
     // Create the receipt and item objects
     Item item1 = new Item("Gatorade", new BigDecimal("2.25"));
     Item item2 = new Item("Gatorade", new BigDecimal("2.25"));

--- a/src/test/java/io/yuchengzang/receiptprocessor/service/ReceiptPointsServiceTest.java
+++ b/src/test/java/io/yuchengzang/receiptprocessor/service/ReceiptPointsServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Collections;
 
@@ -603,5 +604,122 @@ public class ReceiptPointsServiceTest {
     });
   }
 
+  /**
+   * Testing rule: 10 points if the time of purchase is after 2:00pm and before 4:00pm.
+   *
+   * Test case: Purchase time is 11:00 (morning), which is before 2:00pm, so the points for this
+   * receipt is 0
+   */
+  @Test
+  void testValidCalculatePointsFromPurchaseTime1100() {
+    testReceipt.setPurchaseTime(LocalTime.parse("11:00"));
+    assertEquals(0, receiptPointsService.calculatePointsFromPurchaseTime(testReceipt));
+  }
+
+  /**
+   * Testing rule: 10 points if the time of purchase is after 2:00pm and before 4:00pm.
+   *
+   * Test case: Purchase time is 13:00, which is before 2:00pm, so the points for this receipt is 0
+   */
+  @Test
+  void testValidCalculatePointsFromPurchaseTime1300() {
+    testReceipt.setPurchaseTime(LocalTime.parse("13:00"));
+    assertEquals(0, receiptPointsService.calculatePointsFromPurchaseTime(testReceipt));
+  }
+
+  /**
+   * Testing rule: 10 points if the time of purchase is after 2:00pm and before 4:00pm.
+   *
+   * Test case: Purchase time is 13:59 (edge case, last minute before 2:00pm), which is before
+   * 2:00pm, so the points for this receipt is 0
+   */
+  @Test
+  void testValidCalculatePointsFromPurchaseTime1359() {
+    testReceipt.setPurchaseTime(LocalTime.parse("13:59"));
+    assertEquals(0, receiptPointsService.calculatePointsFromPurchaseTime(testReceipt));
+  }
+
+  /**
+   * Testing rule: 10 points if the time of purchase is after 2:00pm and before 4:00pm.
+   *
+   * Test case: Purchase time is 14:00 (edge case, excatlly 2:00pm), which is NOT after 2:00pm, so
+   * the points for this receipt is 10
+   */
+  @Test
+  void testValidCalculatePointsFromPurchaseTime1400() {
+    testReceipt.setPurchaseTime(LocalTime.parse("14:00"));
+    assertEquals(0, receiptPointsService.calculatePointsFromPurchaseTime(testReceipt));
+  }
+
+  /**
+   * Testing rule: 10 points if the time of purchase is after 2:00pm and before 4:00pm.
+   *
+   * Test case: Purchase time is 14:01 (edge case, first minute after 2:00pm), which is after 2:00pm,
+   * so the points for this receipt is 10
+   */
+  @Test
+  void testValidCalculatePointsFromPurchaseTime1401() {
+    testReceipt.setPurchaseTime(LocalTime.parse("14:01"));
+    assertEquals(10, receiptPointsService.calculatePointsFromPurchaseTime(testReceipt));
+  }
+
+  /**
+   * Testing rule: 10 points if the time of purchase is after 2:00pm and before 4:00pm.
+   *
+   * Test case: Purchase time is 14:23, which is after 2:00pm and before 4:00pm, so the points for
+   * this receipt is 10
+   */
+  @Test
+  void testValidCalculatePointsFromPurchaseTime1423() {
+    testReceipt.setPurchaseTime(LocalTime.parse("14:23"));
+    assertEquals(10, receiptPointsService.calculatePointsFromPurchaseTime(testReceipt));
+  }
+
+  /**
+   * Testing rule: 10 points if the time of purchase is after 2:00pm and before 4:00pm.
+   *
+   * Test case: Purchase time is 15:21, which is after 2:00pm and before 4:00pm, so the points for
+   * this receipt is 10
+   */
+  @Test
+  void testValidCalculatePointsFromPurchaseTime1521() {
+    testReceipt.setPurchaseTime(LocalTime.parse("15:21"));
+    assertEquals(10, receiptPointsService.calculatePointsFromPurchaseTime(testReceipt));
+  }
+
+  /**
+   * Testing rule: 10 points if the time of purchase is after 2:00pm and before 4:00pm.
+   *
+   * Test case: Purchase time is 15:59 (edge case, last minute before 4:00pm), which is before 4:00pm,
+   * so the points for this receipt is 10
+   */
+  @Test
+  void testValidCalculatePointsFromPurchaseTime1559() {
+    testReceipt.setPurchaseTime(LocalTime.parse("15:59"));
+    assertEquals(10, receiptPointsService.calculatePointsFromPurchaseTime(testReceipt));
+  }
+
+  /**
+   * Testing rule: 10 points if the time of purchase is after 2:00pm and before 4:00pm.
+   *
+   * Test case: Purchase time is 16:00 (edge case, first minute after 4:00pm), which is NOT before
+   * 4:00pm, so the points for this receipt is 0
+   */
+  @Test
+  void testValidCalculatePointsFromPurchaseTime1600() {
+    testReceipt.setPurchaseTime(LocalTime.parse("16:00"));
+    assertEquals(0, receiptPointsService.calculatePointsFromPurchaseTime(testReceipt));
+  }
+
+  /**
+   * Testing rule: 10 points if the time of purchase is after 2:00pm and before 4:00pm.
+   *
+   * Test case: Purchase time is 17:00, which is after 4:00pm, so the points for this receipt is 0
+   */
+  @Test
+  void testValidCalculatePointsFromPurchaseTime1700() {
+    testReceipt.setPurchaseTime(LocalTime.parse("17:00"));
+    assertEquals(0, receiptPointsService.calculatePointsFromPurchaseTime(testReceipt));
+  }
 
 }

--- a/src/test/java/io/yuchengzang/receiptprocessor/service/ReceiptPointsServiceTest.java
+++ b/src/test/java/io/yuchengzang/receiptprocessor/service/ReceiptPointsServiceTest.java
@@ -378,5 +378,162 @@ public class ReceiptPointsServiceTest {
     });
   }
 
+  /**
+   * Testing rule: If the trimmed length of the item description is a multiple of 3, multiply the
+   * price by 0.2 and round up to the nearest integer. The result is the number of points earned.
+   *
+   * Test case: 1 item.
+   * Item: "Mountain Dew 12PK", Price: $5.99, Points: 0
+   * (The trimmed length is 17, which is not a multiple of 3)
+   */
+  @Test
+  void testValidCalculatePointsFromItemDescriptionLength1ItemTest1() {
+    Item item = new Item("Mountain Dew 12PK", new BigDecimal("5.99"));
+    testReceipt.setItems(List.of(item));
+
+    assertEquals(0,
+        receiptPointsService.calculatePointsFromItemDescriptionLength(testReceipt));
+  }
+
+  /**
+   * Testing rule: If the trimmed length of the item description is a multiple of 3, multiply the
+   * price by 0.2 and round up to the nearest integer. The result is the number of points earned.
+   *
+   * Test case: 1 item.
+   * Item: "Coca-Cola 12PKG", Price: $5.99, Points: 2
+   * (trimmed length is 15, which is a multiple of 3. points = 5.99 * 0.2 = 1.198, rounded up to 2)
+   */
+  @Test
+  void testValidCalculatePointsFromItemDescriptionLength1ItemTest2() {
+    Item item = new Item("Coca-Cola 12PKG", new BigDecimal("5.99"));
+    testReceipt.setItems(List.of(item));
+
+    assertEquals(2,
+        receiptPointsService.calculatePointsFromItemDescriptionLength(testReceipt));
+  }
+
+  /**
+   * Testing rule: If the trimmed length of the item description is a multiple of 3, multiply the
+   * price by 0.2 and round up to the nearest integer. The result is the number of points earned.
+   *
+   * Test case: 1 item.
+   * Item: "Emils Cheese Pizza", Price: $12.25, Points: 3
+   * (trimmed length is 18, which is a multiple of 3. points = 12.25 * 0.2 = 2.45, rounded up to 3)
+   */
+  @Test
+  void testValidCalculatePointsFromItemDescriptionLength1ItemTest3() {
+    Item item = new Item("Emils Cheese Pizza", new BigDecimal("12.25"));
+    testReceipt.setItems(List.of(item));
+
+    assertEquals(3,
+        receiptPointsService.calculatePointsFromItemDescriptionLength(testReceipt));
+  }
+
+  /**
+   * Testing rule: If the trimmed length of the item description is a multiple of 3, multiply the
+   * price by 0.2 and round up to the nearest integer. The result is the number of points earned.
+   *
+   * Test case: 1 item.
+   * Item: "   Klarbrunn 12-PK 12 FL OZ  ", Price: $12.00, Points: 3
+   * (trimmed length is 24, which is a multiple of 3. points = 12.00 * 0.2 = 2.4, rounded up to 3)
+   */
+  @Test
+  void testValidCalculatePointsFromItemDescriptionLength1ItemTest4() {
+    Item item = new Item("   Klarbrunn 12-PK 12 FL OZ  ", new BigDecimal("12.00"));
+    testReceipt.setItems(List.of(item));
+
+    assertEquals(3,
+        receiptPointsService.calculatePointsFromItemDescriptionLength(testReceipt));
+  }
+
+  /**
+   * Testing rule: If the trimmed length of the item description is a multiple of 3, multiply the
+   * price by 0.2 and round up to the nearest integer. The result is the number of points earned.
+   *
+   * Test case: 2 items.
+   * Item1: "Mountain Dew 12PK", Price: $5.99
+   * (The trimmed length is 17, which is not a multiple of 3)
+   * Item2: "Coca-Cola 12PKG", Price: $5.99
+   * (trimmed length is 15, which is a multiple of 3. points = 5.99 * 0.2 = 1.198, rounded up to 2)
+   * Points: 2
+   */
+  @Test
+  void testValidCalculatePointsFromItemDescriptionLength2ItemsTest1() {
+    Item item1 = new Item("Mountain Dew 12PK", new BigDecimal("5.99"));
+    Item item2 = new Item("Coca-Cola 12PKG", new BigDecimal("5.99"));
+    testReceipt.setItems(List.of(item1, item2));
+
+    assertEquals(2,
+        receiptPointsService.calculatePointsFromItemDescriptionLength(testReceipt));
+  }
+
+  /**
+   * Testing rule: If the trimmed length of the item description is a multiple of 3, multiply the
+   * price by 0.2 and round up to the nearest integer. The result is the number of points earned.
+   *
+   * Test case: 2 items.
+   * Item1: "Coca-Cola 12PKG", Price: $5.99
+   * (trimmed length is 15, which is a multiple of 3. points = 5.99 * 0.2 = 1.198, rounded up to 2)
+   * Item2: "Emils Cheese Pizza", Price: $12.25
+   * (trimmed length is 18, which is a multiple of 3. points = 12.25 * 0.2 = 2.45, rounded up to 3)
+   * Points: 5
+   */
+  @Test
+  void testValidCalculatePointsFromItemDescriptionLength2ItemsTest2() {
+    Item item1 = new Item("Coca-Cola 12PKG", new BigDecimal("5.99"));
+    Item item2 = new Item("Emils Cheese Pizza", new BigDecimal("12.25"));
+    testReceipt.setItems(List.of(item1, item2));
+
+    assertEquals(5,
+        receiptPointsService.calculatePointsFromItemDescriptionLength(testReceipt));
+  }
+
+  /**
+   * Testing rule: If the trimmed length of the item description is a multiple of 3, multiply the
+   * price by 0.2 and round up to the nearest integer. The result is the number of points earned.
+   *
+   * Test case: 500 items.
+   * Item: "Mountain Dew 12PK", Price: $5.99
+   *
+   * It adds 500 items with the same description and price. The trimmed length of the description
+   * is 17, which is not a multiple of 3, so the points for this receipt is 0.
+   */
+  @Test
+  void testValidCalculatePointsFromItemDescriptionLengthSmoke1() {
+    Item item = new Item("Mountain Dew 12PK", new BigDecimal("5.99"));
+    List<Item> items = Collections.nCopies(500, item);
+    testReceipt.setItems(items);
+
+    assertEquals(0,
+        receiptPointsService.calculatePointsFromItemDescriptionLength(testReceipt));
+  }
+
+  /**
+   * Testing rule: If the trimmed length of the item description is a multiple of 3, multiply the
+   * price by 0.2 and round up to the nearest integer. The result is the number of points earned.
+   *
+   * Test case: 500 items.
+   * Item: "Emils Cheese Pizza", Price: $12.25
+   *
+   * It adds 500 items with the same description and price. The trimmed length of the description
+   * is 18, which is a multiple of 3, so the points for this receipt is 3 * 500 = 1500.
+   */
+  @Test
+  void testValidCalculatePointsFromItemDescriptionLengthSmoke2() {
+    Item item = new Item("Emils Cheese Pizza", new BigDecimal("12.25"));
+    List<Item> items = Collections.nCopies(500, item);
+    testReceipt.setItems(items);
+
+    assertEquals(1500,
+        receiptPointsService.calculatePointsFromItemDescriptionLength(testReceipt));
+  }
+
+  @Test
+  void testInvalidCalculatePointsFromItemDescriptionLengthNullReceipt() {
+    assertThrows(IllegalArgumentException.class, () -> {
+      receiptPointsService.calculatePointsFromItemDescriptionLength(null);
+    });
+  }
+
 
 }

--- a/src/test/java/io/yuchengzang/receiptprocessor/service/ReceiptPointsServiceTest.java
+++ b/src/test/java/io/yuchengzang/receiptprocessor/service/ReceiptPointsServiceTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.BeforeEach;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Collections;
 
@@ -532,6 +533,73 @@ public class ReceiptPointsServiceTest {
   void testInvalidCalculatePointsFromItemDescriptionLengthNullReceipt() {
     assertThrows(IllegalArgumentException.class, () -> {
       receiptPointsService.calculatePointsFromItemDescriptionLength(null);
+    });
+  }
+
+  /**
+   * Testing rule: 6 points if the day in the purchase date is odd.
+   *
+   * Test case: Purchase date is 2022-01-01, which is an odd day, so the points for this receipt
+   * is 6
+   */
+  @Test
+  void testValidCalculatePointsFromPurchaseDateJan01() {
+    testReceipt.setPurchaseDate(LocalDate.parse("2022-01-01"));
+    assertEquals(6, receiptPointsService.calculatePointsFromPurchaseDate(testReceipt));
+  }
+
+  /**
+   * Testing rule: 6 points if the day in the purchase date is odd.
+   *
+   * Test case: Purchase date is 2022-01-02, which is not an odd day, so the points for this receipt
+   * is 0
+   */
+  @Test
+  void testValidCalculatePointsFromPurchaseDateJan02() {
+    testReceipt.setPurchaseDate(LocalDate.parse("2022-01-02"));
+    assertEquals(0, receiptPointsService.calculatePointsFromPurchaseDate(testReceipt));
+  }
+
+  /**
+   * Testing rule: 6 points if the day in the purchase date is odd.
+   *
+   * Test case: Purchase date is 2022-01-31 (edge case, the last day of of a month), which is an odd
+   * day, so the points for this receipt is 6
+   */
+  @Test
+  void testValidCalculatePointsFromPurchaseDateJan31() {
+    testReceipt.setPurchaseDate(LocalDate.parse("2022-01-31"));
+    assertEquals(6, receiptPointsService.calculatePointsFromPurchaseDate(testReceipt));
+  }
+
+  /**
+   * Testing rule: 6 points if the day in the purchase date is odd.
+   *
+   * Test case: Purchase date is 2022-02-28 (edge case, the last day of a month), which is not an
+   * odd day, so the points for this receipt is 0
+   */
+  @Test
+  void testValidCalculatePointsFromPurchaseDateFeb28() {
+    testReceipt.setPurchaseDate(LocalDate.parse("2022-02-28"));
+    assertEquals(0, receiptPointsService.calculatePointsFromPurchaseDate(testReceipt));
+  }
+
+  /**
+   * Testing rule: 6 points if the day in the purchase date is odd.
+   *
+   * Test case: Purchase date is 2020-02-29 (edge case, a leap year), which is an odd day, so the
+   * points for this receipt is 6
+   */
+  @Test
+  void testValidCalculatePointsFromPurchaseDateFeb29() {
+    testReceipt.setPurchaseDate(LocalDate.parse("2020-02-29"));
+    assertEquals(6, receiptPointsService.calculatePointsFromPurchaseDate(testReceipt));
+  }
+
+  @Test
+  void testInvalidCalculatePointsFromPurchaseDateNullReceipt() {
+    assertThrows(IllegalArgumentException.class, () -> {
+      receiptPointsService.calculatePointsFromPurchaseDate(null);
     });
   }
 

--- a/src/test/java/io/yuchengzang/receiptprocessor/service/ReceiptPointsServiceTest.java
+++ b/src/test/java/io/yuchengzang/receiptprocessor/service/ReceiptPointsServiceTest.java
@@ -1,0 +1,105 @@
+package io.yuchengzang.receiptprocessor.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.yuchengzang.receiptprocessor.model.Receipt;
+public class ReceiptPointsServiceTest {
+
+  /**
+   * A empty receipt that can be assigned with various different values for testing.
+   */
+  private Receipt testReceipt;
+
+  /**
+   * A ReceiptPointsService object that can be used to test the calculatePoints method.
+   */
+  private ReceiptPointsService receiptPointsService;
+
+  @BeforeEach
+  void setUp() {
+    testReceipt = new Receipt();
+    receiptPointsService = new ReceiptPointsService();
+  }
+
+  /**
+   * Testing rule: One point for every alphanumeric character in the retailer name.
+   *
+   * Test case: Retailer name is "Target1076", which has 10 alphanumeric characters, so the points
+   * should be 10.
+   */
+  @Test
+  void testValidCalculatePointsFromRetailerNameOnlyAlphanumeric1() {
+    testReceipt.setRetailer("Target1076");
+    assertEquals(10, receiptPointsService.calculatePointsFromRetailerName(testReceipt));
+  }
+
+  /**
+   * Testing rule: One point for every alphanumeric character in the retailer name.
+   *
+   * Test case: Retailer name is "12Walmart", which has 9 alphanumeric characters, so the points
+   * should be 9.
+   */
+  @Test
+  void testValidCalculatePointsFromRetailerNameOnlyAlphanumeric2() {
+    testReceipt.setRetailer("12Walmart");
+    assertEquals(9, receiptPointsService.calculatePointsFromRetailerName(testReceipt));
+  }
+
+  /**
+   * Testing rule: One point for every alphanumeric character in the retailer name.
+   *
+   * Test case: Retailer name is "M&M Corner Market", which has 14 alphanumeric characters (' ' and
+   * '&' are not counted), so the points should be 14.
+   */
+  @Test
+  void testValidCalculatePointsFromRetailerNameComplex1() {
+    testReceipt.setRetailer("M&M Corner Market");
+    assertEquals(14, receiptPointsService.calculatePointsFromRetailerName(testReceipt));
+  }
+
+  /**
+   * Testing rule: One point for every alphanumeric character in the retailer name.
+   *
+   * Test case: Retailer name is "Costco Gas #1020", which has 13 alphanumeric characters (' ' and
+   * '#' are not counted), so the points should be 13.
+   */
+  @Test
+  void testValidCalculatePointsFromRetailerNameComplex2() {
+    testReceipt.setRetailer("Costco Gas #1020");
+    assertEquals(13, receiptPointsService.calculatePointsFromRetailerName(testReceipt));
+  }
+
+  /**
+   * Testing rule: One point for every alphanumeric character in the retailer name.
+   *
+   * Test case: Retailer name is "!@#$%^&123456789    ?? 123jihoiny|| abc abc abc ", which has 28
+   * alphanumeric characters (' ' and special characters are not counted), so the points should be
+   * 28.
+   */
+  @Test
+  void testValidCalculatePointsFromRetailerNameSmoke() {
+    testReceipt.setRetailer("!@#$%^&123456789    ?? 123jihoiny|| abc abc abc ");
+    assertEquals(28, receiptPointsService.calculatePointsFromRetailerName(testReceipt));
+  }
+
+  /**
+   * Testing rule: One point for every alphanumeric character in the retailer name.
+   *
+   * Test case: Retailer name is "#!!!???", which has 0 alphanumeric characters, so the points
+   * should be 0.
+   */
+  @Test
+  void testValidCalculatePointsFromRetailerNameNoAlphanumeric() {
+    testReceipt.setRetailer("#!!!???");
+    assertEquals(0, receiptPointsService.calculatePointsFromRetailerName(testReceipt));
+  }
+
+  @Test
+  void testInvalidCalculatePointsFromRetailerNameNullReceipt() {
+    assertThrows(IllegalArgumentException.class, () -> {
+      receiptPointsService.calculatePointsFromRetailerName(null);
+    });
+  }
+}


### PR DESCRIPTION
### Pull Request Description

- **Overview**:
  - Implements the core `calculatePoints()` method to compute points for receipts based on defined rules.
  - Adds a comprehensive test suite to ensure accurate calculation and rule adherence.

- **Features Implemented**:
  - `calculatePointsFromRetailerName`: Adds points based on the alphanumeric character count in the retailer's name.
  - `calculatePointsFromTotalAmountRoundDollar`: Adds 50 points if the total is a round dollar amount.
  - `calculatePointsFromTotalAmountMultipleOfQuarter`: Adds 25 points if the total is a multiple of 0.25.
  - `calculatePointsFromItemCount`: Adds 5 points for every two items on the receipt.
  - `calculatePointsFromItemDescriptionLength`: Adds points based on the item description length if it's a multiple of 3.
  - `calculatePointsFromPurchaseDate`: Adds 6 points if the purchase date's day is odd.
  - `calculatePointsFromPurchaseTime`: Adds 10 points if the purchase time is between 2:00 PM and 4:00 PM.

- **Testing**:
  - Includes individual unit tests for each rule.
  - Adds integration tests for the `calculatePoints()` method with multiple receipt scenarios:
    - Simple receipt (/examples/simple-receipt.json)
    - Morning receipt (/examples/morning-receipt.json)
    - Target receipt (in `README.md`'s `Examples` section)
    - M&M Corner Market receipt (in `README.md`'s `Examples` section)

- **Logging**:
  - Detailed logging for each calculation step, ensuring traceability and transparency.
  - Logs include receipt ID, rule name, and points contributed by each rule.

- **Why Merge This**:
  - Finalizes the points calculation feature as the core service of the project.
  - Provides a strong foundation for adding a RESTful API in the next phase.
